### PR TITLE
Fix log

### DIFF
--- a/challenge_scoring/metrics/scoring.py
+++ b/challenge_scoring/metrics/scoring.py
@@ -136,7 +136,7 @@ def score_submission(streamlines_fname,
         dictionnary containing a score for each metric
     """
     if verbose:
-        logging.basicConfig(level=logging.DEBUG)
+        logging.getLogger().setLevel(level=logging.DEBUG)
         # Silencing SFT's logger if our logging is in DEBUG mode, because it
         # typically produces a lot of outputs!
         set_sft_logger_level('WARNING')

--- a/scripts/score_tractogram.py
+++ b/scripts/score_tractogram.py
@@ -87,7 +87,7 @@ def main():
     out_dir = args.out_dir
 
     if args.verbose:
-        logging.basicConfig(level=logging.DEBUG)
+        logging.getLogger().setLevel(level=logging.DEBUG)
 
     if not os.path.isfile(tractogram):
         parser.error('"{0}" must be a file!'.format(tractogram))


### PR DESCRIPTION
Using basic config is dangerous. If any installed package on the computer imports things badly, it breaks. (Ex, on my computer, dipy 1.5). Making logging setup more stable.